### PR TITLE
Load the environment config by uncommenting a line

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,4 +3,9 @@ ENV['RACK_ENV'] ||= "development"
 
 #require 'sqlite3'
 require_relative 'config/environment.rb'
+require 'active_record'
+require 'sinatra'
+require 'sinatra/activerecord'
+set :database, {adapter: "sqlite3", database: "db/#{ENV['SINATRA_ENV']}.sqlite"}
+
 require 'sinatra/activerecord/rake'

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,6 @@
 ENV['SINATRA_ENV'] ||= "development"
+ENV['RACK_ENV'] ||= "development"
+
 #require 'sqlite3'
 require_relative 'config/environment.rb'
 require 'sinatra/activerecord/rake'

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,4 @@
 ENV['SINATRA_ENV'] ||= "development"
 #require 'sqlite3'
-#require_relative 'config/environment.rb'
+require_relative 'config/environment.rb'
 require 'sinatra/activerecord/rake'

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,8 +1,9 @@
 ENV['SINATRA_ENV'] ||= "development"
-require "rubygems"
+
 require "sinatra"
+
 require "active_record"
-#require "sinatra/activerecord"
+require "sinatra/activerecord"
 #require 'bundler/setup'
 #Bundler.require(:default, ENV['SINATRA_ENV'])
 #require "Bundler"
@@ -13,6 +14,7 @@ ActiveRecord::Base.establish_connection(
 	:adapter => 'sqlite3',
 	:database => "db/#{ENV['SINATRA_ENV']}.sqlite"
 )
+
 #configure :development do
 #  set :database, 'sqlite3:db/database.db'
 #end
@@ -20,4 +22,4 @@ ActiveRecord::Base.establish_connection(
 #require_all 'app'
 
 #Link To Models Here
-require "models/car.rb"
+# require "models/car.rb"


### PR DESCRIPTION
This fixes an issue creating this error:

> ActiveRecord::AdapterNotSpecified: The `development` database is not configured for the `default_env` environment.